### PR TITLE
Fixed #134 "broken indentation"

### DIFF
--- a/src/loguepkg/tml/app.nim
+++ b/src/loguepkg/tml/app.nim
@@ -5,11 +5,12 @@ import ./urls
 
 let
   env = loadPrologueEnv(".env")
-  settings = newSettings(appName = env.getOrDefault("appName", "Prologue"),
-                         debug = env.getOrDefault("debug", true),
-                         port = Port(env.getOrDefault("port", 8080)),
-                         secretKey = env.getOrDefault("secretKey", "")
-    )
+  settings = newSettings(
+    appName = env.getOrDefault("appName", "Prologue"),
+    debug = env.getOrDefault("debug", true),
+    port = Port(env.getOrDefault("port", 8080)),
+    secretKey = env.getOrDefault("secretKey", "")
+  )
 
 
 var app = newApp(settings = settings)


### PR DESCRIPTION
Issue #134 (https://github.com/planety/prologue/issues/134) of the prologue project mentioned that the indentation here was non standard for nim projects.
Since it's a really easy and quick fix I thought I might as well.